### PR TITLE
Add one more Entertain Slot to T3 Layout

### DIFF
--- a/DefaultColony/ColonyFiller.cpp
+++ b/DefaultColony/ColonyFiller.cpp
@@ -90,9 +90,9 @@ bool ColonyFiller::FillSingleSlot(Simulator::cBuilding* building, ResourceKey bu
 }
 
 void ColonyFiller::FillOptimalLayout() {
-	vector<int> mHouseSlotList = {7, 8, 9, 10, 11};
-	vector<int> mEntertainSlotList = {1, 6};
-	vector<int> mIndustrySlotList = {1, 3, 4, 5};
+	vector<int> mHouseSlotList = {6, 7, 8, 9, 10, 11};
+	vector<int> mEntertainSlotList = {5, 10};
+	vector<int> mIndustrySlotList = {1, 2, 3, 4, 5};
 	Simulator::cCommunityLayout buildingLayout = mCity->mBuildingsLayout;
 
 	// fill entertainment building slots

--- a/DefaultColony/ColonyFiller.cpp
+++ b/DefaultColony/ColonyFiller.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "TurretPtrFix.h"
 #include <Spore\BasicIncludes.h>
 #include "ColonyFiller.h"
 #include <Spore\Simulator\SubSystem\GameNounManager.h>
@@ -90,9 +91,9 @@ bool ColonyFiller::FillSingleSlot(Simulator::cBuilding* building, ResourceKey bu
 }
 
 void ColonyFiller::FillOptimalLayout() {
-	vector<int> mHouseSlotList = {6, 7, 8, 9, 10, 11};
+	vector<int> mHouseSlotList = {6, 7, 8, 9, 11};
 	vector<int> mEntertainSlotList = {5, 10};
-	vector<int> mIndustrySlotList = {1, 2, 3, 4, 5};
+	vector<int> mIndustrySlotList = {1, 2, 3, 4};
 	Simulator::cCommunityLayout buildingLayout = mCity->mBuildingsLayout;
 
 	// fill entertainment building slots

--- a/DefaultColony/ColonyFiller.cpp
+++ b/DefaultColony/ColonyFiller.cpp
@@ -90,8 +90,8 @@ bool ColonyFiller::FillSingleSlot(Simulator::cBuilding* building, ResourceKey bu
 }
 
 void ColonyFiller::FillOptimalLayout() {
-	vector<int> mHouseSlotList = {6, 7, 8, 9, 10, 11};
-	vector<int> mEntertainSlotList = {2};
+	vector<int> mHouseSlotList = {7, 8, 9, 10, 11};
+	vector<int> mEntertainSlotList = {1, 6};
 	vector<int> mIndustrySlotList = {1, 3, 4, 5};
 	Simulator::cCommunityLayout buildingLayout = mCity->mBuildingsLayout;
 

--- a/DefaultColony/TurretPtrFix.h
+++ b/DefaultColony/TurretPtrFix.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <Spore/Simulator/cTurret.h>
+
+namespace Simulator {
+    inline void intrusive_ptr_add_ref(cTurret* ptr) {
+        ptr->cGameData::AddRef();
+    }
+
+    inline void intrusive_ptr_release(cTurret* ptr) {
+        ptr->cGameData::Release();
+    }
+}


### PR DESCRIPTION
It is possible to add one more entertainment building and maintain the same amount of production on a T3 planet colony, as shown in the example image below.

I tried to compile the mod to test the change, but it gives me a compilation error. However, I believe that the following change in line 93 and 94 of the ColonyFiller.cpp file should create the same layout as in the image.

_Update: I was able to compile and see what the correct numbers are.._

```
vector<int> mHouseSlotList = {6, 7, 8, 9, 11};
vector<int> mEntertainSlotList = {5, 10};
vector<int> mIndustrySlotList = {1, 2, 3, 4};
```

![Captura de tela 2025-04-08 014603](https://github.com/user-attachments/assets/50f02d22-b159-4816-85c8-068084a90e9c)